### PR TITLE
Use CPU as default device for HW and SIR

### DIFF
--- a/models/HarrisWilson/HarrisWilson_cfg.yml
+++ b/models/HarrisWilson/HarrisWilson_cfg.yml
@@ -37,6 +37,7 @@ NeuralNet:
 Training:
   to_learn: [alpha, beta, kappa, sigma]
   batch_size: !is-positive-int 1
+  device: cpu
 
 # Whether to write out the computation time for each epoch
 write_time: False

--- a/models/SIR/SIR_cfg.yml
+++ b/models/SIR/SIR_cfg.yml
@@ -24,6 +24,6 @@ NeuralNet:
 Training:
   batch_size: !is-positive-int 1
   to_learn: [ p_infect, t_infectious, sigma ]
-  device: ~
+  device: cpu
   num_threads: ~
 


### PR DESCRIPTION
Using the GPU (on Apple Silicon) slows training down significantly, as a number of functions have not yet been implemented for SOCs. This MR sets the default training device to the CPU for both.