### PR TITLE
Allow specifying biases on each layer of the neural net

### DIFF
--- a/models/HarrisWilson/HarrisWilson_cfg.yml
+++ b/models/HarrisWilson/HarrisWilson_cfg.yml
@@ -27,9 +27,10 @@ Data:
 NeuralNet:
   num_layers: !is-positive-int 1
   nodes_per_layer: !is-positive-int 20
-  activation_funcs: abs
-  bias: !is-bool True
-  init_bias: [0, 4]
+  activation_funcs:
+    0: None
+    1: abs
+  biases: [0, 4]
   learning_rate: !is-positive 0.002
 
 # Settings for the neural net training

--- a/models/HarrisWilson/cfgs/London_dataset/run.yml
+++ b/models/HarrisWilson/cfgs/London_dataset/run.yml
@@ -19,7 +19,7 @@ parameter_space:
         origin_zones: data/HarrisWilson/London_data/origin_sizes.csv
         destination_zones: data/HarrisWilson/London_data/dest_sizes.csv
     NeuralNet:
-      init_bias: [ 0, 4 ]
+      biases: [ 0, 4 ]
       num_layers: 1
       nodes_per_layer: 20
       optimizer: Adam

--- a/models/HarrisWilson/cfgs/Loss_landscape/run.yml
+++ b/models/HarrisWilson/cfgs/Loss_landscape/run.yml
@@ -21,8 +21,7 @@ parameter_space:
       nodes_per_layer: 20
       activation_funcs:
         -1: abs
-      bias: True
-      init_bias: [ 0, 4 ]
+      biases: [ 0, 4 ]
       learning_rate: 0.002
       optimizer: Adam
 

--- a/models/HarrisWilson/cfgs/Marginals/run.yml
+++ b/models/HarrisWilson/cfgs/Marginals/run.yml
@@ -30,8 +30,7 @@ parameter_space:
       nodes_per_layer: 20
       activation_funcs:
         -1: abs
-      bias: true
-      init_bias: [0, 4]
+      biases: [0, 4]
       learning_rate: 0.002
       optimizer: Adam
     Training:

--- a/models/HarrisWilson/cfgs/Performance_analysis/run.yml
+++ b/models/HarrisWilson/cfgs/Performance_analysis/run.yml
@@ -35,8 +35,7 @@ parameter_space:
       nodes_per_layer: 20
       activation_funcs:
         -1: abs
-      bias: True
-      init_bias: [ 0, 4 ]
+      biases: [ 0, 4 ]
       learning_rate: 0.002
       optimizer: Adam
 

--- a/models/HarrisWilson/cfgs/Sample_run/run.yml
+++ b/models/HarrisWilson/cfgs/Sample_run/run.yml
@@ -14,9 +14,9 @@ parameter_space:
     NeuralNet:
       num_layers: 1
       nodes_per_layer: 20
-      activation_funcs: abs
-      bias: True
-      init_bias: [ 0, 4 ]
+      activation_funcs:
+        -1: abs
+      biases: [ 0, 4 ]
       learning_rate: 0.002
       optimizer: Adam
 

--- a/models/SIR/SIR_cfg.yml
+++ b/models/SIR/SIR_cfg.yml
@@ -17,8 +17,6 @@ NeuralNet:
   nodes_per_layer: !is-positive-int 20
   activation_funcs:
     -1: abs
-  bias: !is-bool False
-  init_bias: [0, 1]
   learning_rate: !is-positive 0.002
 
 Training:

--- a/models/SIR/cfgs/Predictions/run.yml
+++ b/models/SIR/cfgs/Predictions/run.yml
@@ -14,8 +14,7 @@ parameter_space:
     NeuralNet:
       num_layers: 1
       nodes_per_layer: 20
-      bias: True
-      init_bias: [0, 1]
+      biases: [0, 1]
       activation_funcs:
         -1: abs
       learning_rate: 0.002

--- a/tests/cfgs/neural_net.yml
+++ b/tests/cfgs/neural_net.yml
@@ -1,12 +1,12 @@
 ---
 # Deep example
-NN_deep1:
+deep1:
   num_layers: 1
   nodes_per_layer: 10
   activation_funcs: sigmoid
 
 # Deep example with different activation functions
-NN_deep2:
+deep2:
   num_layers: 3
   nodes_per_layer: 15
   activation_funcs:
@@ -15,16 +15,15 @@ NN_deep2:
     3: tanh
 
 # Deep example with activation functions only on first and last layer
-NN_deep3:
+deep3:
   num_layers: 5
   nodes_per_layer: 5
   activation_funcs:
     0: sigmoid
     -1: tanh
-  init_bias: [-3, -2]
-  bias: True
+  biases: [-3, -2]
 
-NN_deep4:
+deep4:
   num_layers: 5
   nodes_per_layer: 5
   activation_funcs:
@@ -32,9 +31,8 @@ NN_deep4:
     args:
       - -2
       - +2
-  bias: False
 
-NN_deep5:
+deep5:
   num_layers: 5
   nodes_per_layer: 5
   activation_funcs:
@@ -46,27 +44,40 @@ NN_deep5:
     1: abs
 
 # Shallow case with no activation function
-NN_shallow1:
+shallow1:
   num_layers: 1
   nodes_per_layer: 5
   activation_funcs: None
 
 # Shallow case with activation function
-NN_shallow2:
+shallow2:
   num_layers: 1
   nodes_per_layer: 5
   activation_funcs: tanh
 
-# Deep case with bias initialised
-NN_bias:
-  num_layers: 2
-  nodes_per_layer: 5
-  init_bias: [-1, 1]
-  bias: True
 
 # Different optimiser function
-NN_SGD:
+SGD:
   num_layers: 1
   nodes_per_layer: 10
   optimiser: SGD
   learning_rate: 0.1
+
+# Identical bias on all layers
+bias:
+  num_layers: 2
+  nodes_per_layer: 5
+  biases: [-1, 1]
+
+# Bias only on some layers
+biases:
+  num_layers: 5
+  nodes_per_layer: 5
+  activation_funcs:
+    0: sigmoid
+    -1: tanh
+  biases:
+    0: [ -3, -2 ]
+    1: [1, 2]
+    2: [-1, 1]
+    5: ~

--- a/tests/core/test_neural_net.py
+++ b/tests/core/test_neural_net.py
@@ -1,5 +1,6 @@
 import sys
 from os.path import dirname as up
+from typing import Sequence
 
 import torch
 from dantro._import_tools import import_module_from_path
@@ -37,18 +38,30 @@ def test_initialisation():
         assert net.layers[0].in_features == input_size
         assert net.layers[-1].out_features == output_size
 
-        bias = config.pop("bias", False)
+        biases = config.pop("biases", None)
 
         for idx, layer in enumerate(net.layers):
 
             # Check whether layer has bias. If bias, check that bias values are within given interval
-            if not bias:
-                assert layer.bias == None
-            else:
+            if biases is None:
+                assert layer.bias is None
+
+            elif isinstance(biases, Sequence):
                 assert [
-                    config["init_bias"][0] <= b <= config["init_bias"][1]
+                    biases[0] <= b <= biases[1]
                     for b in layer.bias
                 ]
+            else:
+                if idx in biases.keys():
+                    if biases[idx] is None:
+                        assert layer.bias is None
+                    else:
+                        assert [
+                            biases[idx][0] <= b <= biases[idx][1]
+                            for b in layer.bias
+                        ]
+                else:
+                    assert layer.bias is None
 
             # Check the layers have correct dimensions
             if idx == 0:

--- a/tests/models/test_SIR_ABM.py
+++ b/tests/models/test_SIR_ABM.py
@@ -4,6 +4,7 @@ from os.path import dirname as up
 import pytest
 import torch
 from dantro._import_tools import import_module_from_path
+from dantro._yaml import load_yml
 from pkg_resources import resource_filename
 
 sys.path.insert(0, up(up(up(__file__))))


### PR DESCRIPTION
Allows specifying the uniform initialisation range of the bias on each layer:

```yaml
 # Initialises the bias on *all* layers in [-1, 1]
biases: [-1, 1]    

 # Initialises the bias differently on each layer:
biases: 
  0: [-1, 1]
  1: [2, 3]
  2: ~
```