### PR TITLE
Allow selecting loss function and interaction kernel smoothing from config

### DIFF
--- a/models/HarrisWilson/HarrisWilson_cfg.yml
+++ b/models/HarrisWilson/HarrisWilson_cfg.yml
@@ -25,17 +25,22 @@ Data:
 
 # Settings for the neural net architecture
 NeuralNet:
-  num_layers: !is-positive-int 1
-  nodes_per_layer: !is-positive-int 20
+  num_layers: 1
+  nodes_per_layer:
+    default: !is-positive-int 20
   activation_funcs:
-    0: None
-    1: abs
-  biases: [0, 4]
+    default: linear
+    layer_specific:
+      1: abs
+  biases:
+    default: [0, 4]
   learning_rate: !is-positive 0.002
 
 # Settings for the neural net training
 Training:
   to_learn: [alpha, beta, kappa, sigma]
+  loss_function:
+    name: MSELoss
   batch_size: !is-positive-int 1
   device: cpu
 

--- a/models/HarrisWilson/cfgs/London_dataset/run.yml
+++ b/models/HarrisWilson/cfgs/London_dataset/run.yml
@@ -19,9 +19,11 @@ parameter_space:
         origin_zones: data/HarrisWilson/London_data/origin_sizes.csv
         destination_zones: data/HarrisWilson/London_data/dest_sizes.csv
     NeuralNet:
-      biases: [ 0, 4 ]
+      biases:
+        default: [ 0, 4 ]
       num_layers: 1
-      nodes_per_layer: 20
+      nodes_per_layer:
+        default: 20
       optimizer: Adam
       learning_rate: 0.002
     Training:

--- a/models/HarrisWilson/cfgs/Loss_landscape/run.yml
+++ b/models/HarrisWilson/cfgs/Loss_landscape/run.yml
@@ -18,16 +18,21 @@ parameter_space:
     # Settings for the neural net architecture
     NeuralNet:
       num_layers: 1
-      nodes_per_layer: 20
+      nodes_per_layer:
+        default: 20
       activation_funcs:
-        -1: abs
-      biases: [ 0, 4 ]
+        default: linear
+        layer_specific:
+          -1: abs
+      biases:
+        default: [ 0, 4 ]
       learning_rate: 0.002
       optimizer: Adam
 
     # Settings for the neural net training
     Training:
       to_learn: [ alpha, beta, kappa ]
+      loss_function: MSELoss
       batch_size: 1
       true_parameters:
         sigma: 0

--- a/models/HarrisWilson/cfgs/Marginals/run.yml
+++ b/models/HarrisWilson/cfgs/Marginals/run.yml
@@ -27,12 +27,17 @@ parameter_space:
         name: sigma
     NeuralNet:
       num_layers: 1
-      nodes_per_layer: 20
+      nodes_per_layer:
+        default: 20
       activation_funcs:
-        -1: abs
-      biases: [0, 4]
+        default: linear
+        layer_specific:
+          -1: abs
+      biases:
+        default: [0, 4]
       learning_rate: 0.002
       optimizer: Adam
     Training:
+      loss_function: MSELoss
       batch_size: 1
       to_learn: [alpha, beta, kappa, sigma]

--- a/models/HarrisWilson/cfgs/Performance_analysis/run.yml
+++ b/models/HarrisWilson/cfgs/Performance_analysis/run.yml
@@ -32,10 +32,14 @@ parameter_space:
     # Settings for the neural net architecture
     NeuralNet:
       num_layers: 1
-      nodes_per_layer: 20
+      nodes_per_layer:
+        default: 20
       activation_funcs:
-        -1: abs
-      biases: [ 0, 4 ]
+        default: None
+        layer_specific:
+          -1: abs
+      biases:
+        default: [ 0, 4 ]
       learning_rate: 0.002
       optimizer: Adam
 

--- a/models/HarrisWilson/cfgs/Sample_run/run.yml
+++ b/models/HarrisWilson/cfgs/Sample_run/run.yml
@@ -13,16 +13,20 @@ parameter_space:
     # Settings for the neural net architecture
     NeuralNet:
       num_layers: 1
-      nodes_per_layer: 20
+      nodes_per_layer:
+        default: 20
       activation_funcs:
-        -1: abs
-      biases: [ 0, 4 ]
+        layer_specific:
+          -1: abs
+      biases:
+        default: [ 0, 4 ]
       learning_rate: 0.002
       optimizer: Adam
 
     # Settings for the neural net training
     Training:
       to_learn: [ alpha, beta, kappa ]
+      loss_function: MSELoss
       batch_size: 1
       true_parameters:
         sigma: 0

--- a/models/SIR/SIR_cfg.yml
+++ b/models/SIR/SIR_cfg.yml
@@ -13,14 +13,21 @@ Data:
     num_steps: 200
 
 NeuralNet:
-  num_layers: !is-positive-int 2
-  nodes_per_layer: !is-positive-int 20
+  num_layers: !is-positive-int 1
+  nodes_per_layer:
+    default: !is-positive-int 20
+  biases:
+    default: [0, 1]
   activation_funcs:
-    -1: abs
+    default: linear
+    layer_specific:
+      -1: abs
   learning_rate: !is-positive 0.002
 
 Training:
   batch_size: !is-positive-int 1
+  loss_function:
+    name: MSELoss
   to_learn: [ p_infect, t_infectious, sigma ]
   device: cpu
   num_threads: ~

--- a/models/SIR/cfgs/Predictions/run.yml
+++ b/models/SIR/cfgs/Predictions/run.yml
@@ -13,12 +13,17 @@ parameter_space:
       load_from_dir: data/SIR/ABM_data/data/uni0/data.h5
     NeuralNet:
       num_layers: 1
-      nodes_per_layer: 20
-      biases: [0, 1]
+      nodes_per_layer:
+        default: 20
+      biases:
+        default: [0, 1]
       activation_funcs:
-        -1: abs
+        default: linear
+        layer_specific:
+          -1: abs
       learning_rate: 0.002
       optimizer: Adam
     Training:
+      loss_function: MSELoss
       batch_size: 90
       to_learn: [p_infect, t_infectious, sigma]

--- a/tests/cfgs/neural_net.yml
+++ b/tests/cfgs/neural_net.yml
@@ -1,83 +1,142 @@
 ---
-# Deep example
-deep1:
-  num_layers: 1
-  nodes_per_layer: 10
-  activation_funcs: sigmoid
+# Simple deep example
+basic_deep:
+  num_layers: 2
+  nodes_per_layer:
+    default: 5
+  activation_funcs:
+    default: sigmoid
+  biases:
+    default: ~
+
+# Deep example with different number of nodes on each layer
+different_num_nodes:
+  num_layers: 10
+  nodes_per_layer:
+    default: 5
+    layer_specific:
+      0: 6
+      3: 1
+      -1: 10
+  activation_funcs:
+    default: sigmoid
+  biases:
+    default: ~
 
 # Deep example with different activation functions
-deep2:
+different_activation_funcs:
   num_layers: 3
-  nodes_per_layer: 15
+  nodes_per_layer:
+    default: 5
   activation_funcs:
-    1: sigmoid
-    2: relu
-    3: tanh
+    default: linear
+    layer_specific:
+      0: sigmoid
+      2: relu
+      -1: tanh
+  biases:
+    default: ~
 
-# Deep example with activation functions only on first and last layer
-deep3:
+# Deep example with different biases
+bias:
   num_layers: 5
-  nodes_per_layer: 5
+  nodes_per_layer:
+    default: 5
   activation_funcs:
-    0: sigmoid
-    -1: tanh
-  biases: [-3, -2]
+    default: sigmoid
+  biases:
+    default: [-3, -2]
+    layer_specific:
+      0: [1, 2]
+      -1: [2, 3]
 
-deep4:
+# Deep example with bias only on some layers:
+some_bias:
   num_layers: 5
-  nodes_per_layer: 5
+  nodes_per_layer:
+    default: 5
   activation_funcs:
-    name: HardTanh
-    args:
-      - -2
-      - +2
+    default: sigmoid
+  biases:
+    default: ~
+    layer_specific:
+      0: [1, 2]
+      -1: [2, 3]
 
-deep5:
+# Deep example with activation funcs requiring args and kwargs
+activation_funcs_with_args:
   num_layers: 5
-  nodes_per_layer: 5
+  nodes_per_layer:
+    default: 5
   activation_funcs:
-    0:
+    default:
       name: HardTanh
       args:
         - -2
         - +2
-    1: abs
+  biases:
+    default: ~
+
+# Deep example with activation funcs requiring args and kwargs
+activation_funcs_with_args_2:
+  num_layers: 5
+  nodes_per_layer:
+    default: 5
+  activation_funcs:
+    default:
+      name: HardTanh
+      args:
+        - -2
+        - +2
+    layer_specific:
+      0: tanh
+      -1:
+        name: Softplus
+        args:
+          - 1.5
+          - 18
+  biases:
+    default: ~
+
 
 # Shallow case with no activation function
-shallow1:
+simple_shallow:
   num_layers: 1
-  nodes_per_layer: 5
-  activation_funcs: None
+  nodes_per_layer:
+    default: 5
+  activation_funcs:
+    default: ~
+  biases:
+    default: ~
 
 # Shallow case with activation function
-shallow2:
+shallow_with_activation_funcs:
   num_layers: 1
-  nodes_per_layer: 5
-  activation_funcs: tanh
+  nodes_per_layer:
+    default: 5
+  activation_funcs:
+    default: tanh
+  biases:
+    default: ~
 
+# Shallow case with bias
+shallow_with_bias:
+  num_layers: 1
+  nodes_per_layer:
+    default: 1
+  activation_funcs:
+    default: tanh
+  biases:
+    default: [-1, 1]
 
 # Different optimiser function
-SGD:
+SGD_optimizer:
   num_layers: 1
-  nodes_per_layer: 10
+  nodes_per_layer:
+    default: 10
+  activation_funcs:
+    default: linear
+  biases:
+    default: ~
   optimiser: SGD
   learning_rate: 0.1
-
-# Identical bias on all layers
-bias:
-  num_layers: 2
-  nodes_per_layer: 5
-  biases: [-1, 1]
-
-# Bias only on some layers
-biases:
-  num_layers: 5
-  nodes_per_layer: 5
-  activation_funcs:
-    0: sigmoid
-    -1: tanh
-  biases:
-    0: [ -3, -2 ]
-    1: [1, 2]
-    2: [-1, 1]
-    5: ~


### PR DESCRIPTION
Allows specifying the loss function and nodes per layer from the config, as well as further improvements to the 
neural net architecture selection interface using a ``default`` and ``layer_specific`` approach:

```yaml

num_layers: 10
nodes_per_layer:
   default: 10
   layer_specific:
      2: 20
activation_funcs:
   default: sigmoid
   layer_specific:
      2: tanh
biases:
   default: [0, 1]
   layer_specific:
     -1: ~
```
   