### PR TITLE
Allow using pytorch default uniform distribution in bias initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ giving the default value, applied to all layers. An optional ``layer_specific`` 
 controls any deviations from the default on specific layers; in the above example,
 all layers have 20 nodes by default, use a sigmoid activation function, and have a bias
 which is initialised uniformly at random on [0, 4]. Layer-specific settings are then provided.
+You can also set the bias initialisation interval to `default`: this will initialise the bias using the [pytorch default](https://github.com/pytorch/pytorch/blob/9a575e77ca8a0be7a3f3625c4dfdc6321d2a0c2d/torch/nn/modules/linear.py#L72)
+Xavier uniform distribution.
 
 Any [pytorch activation function](https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity)
 is supported, such as ``relu``, ``linear``, ``tanh``, ``sigmoid``, etc. Some activation functions take arguments and

--- a/include/neural_net.py
+++ b/include/neural_net.py
@@ -219,7 +219,13 @@ class NeuralNet(nn.Module):
 
             # Initialise the biases of the layers with a uniform distribution
             if self.bias[i] is not None:
-                torch.nn.init.uniform_(layer.bias, self.bias[i][0], self.bias[i][1])
+                # Use the pytorch default if indicated
+                if self.bias[i] == 'default':
+                    torch.nn.init.uniform_(layer.bias)
+                # Initialise the bias on explicitly provided intervals
+                else:
+                    torch.nn.init.uniform_(layer.bias, self.bias[i][0], self.bias[i][1])
+
 
             self.layers.append(layer)
 


### PR DESCRIPTION
This allows using the `default` keyword to initialise biases using the pytorch default (Xavier uniform)