### PR TITLE
Improve SIR plots

### DIFF
--- a/.utopya-project.yml
+++ b/.utopya-project.yml
@@ -20,8 +20,27 @@ paths:
   py_tests_dir: tests
 
 metadata:
-  description: Neural agent-based modelling project
+  long_description: Neural agent-based modelling project
   authors:
     - Thomas Gaskin
   license: LGPLv3+
   language: python3
+  version: ~
+  long_name: ~
+  email: ~
+  website: ~
+  utopya_compatibility: ~
+  misc: ~
+  requirements: ~
+  description: ~
+
+cfg_set_abs_search_dirs: ~
+cfg_set_model_source_subdirs: ~
+custom_py_modules: ~
+output_files: ~
+debug_level_updates: ~
+framework_name: ~
+
+settings:
+  preload_project_py_plots: ~
+  preload_framework_py_plots: ~

--- a/cfg/multiverse_project_cfg.yml
+++ b/cfg/multiverse_project_cfg.yml
@@ -6,7 +6,7 @@ executable_control:
   run_from_tmpdir: false
 
 parameter_space:
-  num_epochs: 1000
+  num_epochs: 100
   write_start: 1
   write_every: 1
 

--- a/model_plots/HarrisWilson/prob_density.py
+++ b/model_plots/HarrisWilson/prob_density.py
@@ -145,7 +145,7 @@ def plot_prob_density(
             [mlines.Line2D([], [], lw=0)] * len(data),
             [
                 info_box_labels[key] + " = " + str(data[key])
-                for key in list(data.keys())
+                for key in list(info_box_labels.keys())
             ],
             loc="best",
             handlelength=0,

--- a/model_plots/SIR_trajectories_from_densities.py
+++ b/model_plots/SIR_trajectories_from_densities.py
@@ -1,0 +1,295 @@
+import logging
+
+import numpy as np
+import torch
+import xarray as xr
+
+import models.SIR
+from models.SIR.DataGeneration import generate_smooth_data
+from utopya.eval import is_operation
+
+log = logging.getLogger(__name__)
+
+
+def _draw_from_marginal(marginal: xr.Dataset) -> float:
+    """Draw a single parameter from a 1-d marginal, given by a Dataset of x-values and
+    associated probabilities"""
+
+    s = np.random.rand()
+    dx = marginal["x"].isel({"bin_idx": 1}) - marginal["x"].isel({"bin_idx": 0})
+    p_total, i = 0, 0
+    while p_total < s:
+        p_total += marginal["p"].isel({"bin_idx": i}) * dx
+        i += 1
+    return marginal["x"].isel({"bin_idx": i}).item()
+
+
+def _mode_from_marginal(marginal: xr.Dataset) -> float:
+    """Returns the mode of the marginal"""
+    argmax = marginal["p"].argmax()
+    return marginal["x"].isel({"bin_idx": argmax}).item()
+
+
+def _get_sample(marginals: xr.Dataset):
+    """Returns an n-dimensional vector of samples for each marginal distribution."""
+    vec = {}
+    for param in marginals.coords["parameter"]:
+        vec[param.item()] = _draw_from_marginal(marginals.sel({"parameter": param}))
+    return vec
+
+
+def _get_mode(marginals: xr.Dataset):
+    """Returns the mode of a marginal"""
+    vec = {}
+    for param in marginals.coords["parameter"]:
+        vec[param.item()] = _mode_from_marginal(marginals.sel({"parameter": param}))
+    return vec
+
+
+def _adjust_for_time_dependency(
+    param_cfg: dict, cfg: dict, true_counts: xr.Dataset
+) -> dict:
+
+    """Adjusts the parameter configuration for time dependent parameters, if given."""
+
+    time_dependent_parameters = cfg["Data"].get("time_dependent_params", {})
+
+    # Extend any time-dependent parameters, if necessary
+    for param in time_dependent_parameters.keys():
+        val = np.zeros(len(true_counts.coords["time"]))
+        i = 0
+        # Replace any time-dependent parameters with a series
+        for j, interval in enumerate(time_dependent_parameters[param]):
+            _, upper = interval
+            if not upper:
+                upper = len(val)
+            while i < upper:
+                val[i] = param_cfg[str(param) + f"_{j}"]
+                i += 1
+        param_cfg[param] = val
+
+    return param_cfg
+
+
+def _densities_from_marginals(
+    data: xr.Dataset,
+    generating_func,
+    *,
+    num_samples: int,
+    true_counts: xr.Dataset,
+    cfg: dict,
+) -> xr.Dataset:
+
+    """Draws N samples for each parameter from a collection of marginals, then runs the simulation and returns the
+    averaged densities, standard deviation, mode, and true counts in a single xr.Dataset, ready to be passed to
+    .plot.facet_grid.line.
+
+    :param data: the xr.Dataset of marginals, indexed by the parameter name
+    :param generating_func: the generating function used to run the model
+    :param num_samples: the number of samples to draw from the marginals
+    :param true_counts: the xr.Dataset of true counts
+    :param cfg: the run configuration of the original data
+    :return: an xr.Dataset of the mean, mode, std, and true densities for all compartments
+    """
+
+    res = []
+    for n in range(num_samples):
+        parameters = _adjust_for_time_dependency(_get_sample(data), cfg, true_counts)
+        generated_data = generating_func(
+            cfg=parameters,
+            num_steps=len(true_counts.coords["time"]) - 1,
+            dt=cfg["Data"]["synthetic_data"].get("dt", None),
+            k_q=cfg["Data"]["synthetic_data"].get("k_q", None),
+            write_init_state=True,
+            init_state=torch.from_numpy(
+                true_counts.isel({"time": 0}, drop=True).data
+            ).float(),
+        ).numpy()
+        res.append(
+            xr.DataArray(
+                data=[np.stack([true_counts, generated_data])],
+                dims=["sample", "type", "time", "kind", "dim_name__0"],
+                coords=dict(
+                    sample=[n],
+                    type=["true_counts", "prediction_mean"],
+                    time=true_counts.coords["time"],
+                    kind=true_counts.coords["kind"],
+                    dim_name__0=true_counts.coords["dim_name__0"],
+                ),
+            )
+        )
+
+    res = xr.concat(res, dim="sample")
+
+    # Perform a run using the mode
+    mode_params = _adjust_for_time_dependency(_get_mode(data), cfg, true_counts)
+    mode_data = generate_smooth_data(
+        cfg=mode_params,
+        num_steps=len(true_counts.coords["time"]) - 1,
+        dt=cfg["Data"]["synthetic_data"].get("dt", None),
+        k_q=cfg["Data"]["synthetic_data"].get("k_q", None),
+        write_init_state=True,
+        init_state=torch.from_numpy(
+            true_counts.isel({"time": 0}, drop=True).data
+        ).float(),
+    ).numpy()
+
+    mode_data = xr.DataArray(
+        data=[mode_data],
+        dims=["type", "time", "kind", "dim_name__0"],
+        coords=dict(
+            type=["prediction_mode"],
+            time=res.coords["time"],
+            kind=res.coords["kind"],
+            dim_name__0=res.coords["dim_name__0"],
+        ),
+    )
+
+    # Calculate the mean and standard deviation
+    mean = xr.concat([res.mean("sample"), mode_data], dim="type")
+    std = xr.concat([res.std("sample"), 0 * mode_data], dim="type")
+
+    data = xr.Dataset(data_vars=dict(mean=mean, std=std))
+
+    return data
+
+
+def _densities_from_joint(
+    parameters: xr.Dataset,
+    prob: xr.Dataset,
+    generating_func,
+    *,
+    true_counts: xr.Dataset,
+    cfg: dict,
+):
+
+    """Runs the model with the estimated parameters, given in the xr.Dataset, and weights each time series with
+    its corresponding probability. The probabilities must be normalised to 1.
+
+    :param data: the xr.Dataset of parameter estimates, indexed by sample
+    :param prob: the xr.Dataset of probabilities associated with each estimate, indexed by sample
+    :param generating_func: the generating function used to run the model
+    :param true_counts: the xr.Dataset of true counts
+    :param cfg: the run configuration of the original data
+    :return: an xr.Dataset of the mean, mode, std, and true densities for all compartments
+    """
+
+    res = []
+    for s in range(len(parameters.coords["sample"])):
+
+        # Construct the configuration, taking time-dependent parameters into account
+        sample = parameters.isel({"sample": s}, drop=True)
+        sample_cfg = dict(
+            (p.item(), sample.sel({"parameter": p}).item())
+            for p in sample.coords["parameter"]
+        )
+        param_cfg = _adjust_for_time_dependency(sample_cfg, cfg, true_counts)
+
+        # Generate smooth data
+        generated_data = generating_func(
+            cfg=param_cfg,
+            num_steps=len(true_counts.coords["time"]) - 1,
+            dt=cfg["Data"]["synthetic_data"].get("dt", None),
+            k_q=cfg["Data"]["synthetic_data"].get("k_q", None),
+            write_init_state=True,
+            init_state=torch.from_numpy(
+                true_counts.isel({"time": 0}, drop=True).data
+            ).float(),
+        ).numpy()
+        res.append(
+            xr.DataArray(
+                data=[[generated_data]],
+                dims=["sample", "type", "time", "kind", "dim_name__0"],
+                coords=dict(
+                    sample=[s],
+                    type=["prediction_mean"],
+                    time=true_counts.coords["time"],
+                    kind=true_counts.coords["kind"],
+                    dim_name__0=true_counts.coords["dim_name__0"],
+                ),
+            )
+        )
+
+    # Concatenate all the time series
+    res = xr.concat(res, dim="sample").squeeze(["dim_name__0"], drop=True)
+
+    # Get the index of the most likely parameter
+    mode_idx = prob.argmax(dim="sample")
+    mode_cfg = dict(
+        (
+            p.item(),
+            parameters.isel({"sample": mode_idx}, drop=True)
+            .sel({"parameter": p})
+            .item(),
+        )
+        for p in parameters.coords["parameter"]
+    )
+
+    # Perform a run using the mode
+    mode_params = _adjust_for_time_dependency(mode_cfg, cfg, true_counts)
+    mode_data = generating_func(
+        cfg=mode_params,
+        num_steps=len(true_counts.coords["time"]) - 1,
+        dt=cfg["Data"]["synthetic_data"].get("dt", None),
+        k_q=cfg["Data"]["synthetic_data"].get("k_q", None),
+        write_init_state=True,
+        init_state=torch.from_numpy(
+            true_counts.isel({"time": 0}, drop=True).data
+        ).float(),
+    ).numpy()
+
+    mode_data = xr.DataArray(
+        data=[mode_data],
+        dims=["type", "time", "kind", "dim_name__0"],
+        coords=dict(
+            type=["prediction_mode"],
+            time=true_counts.coords["time"],
+            kind=true_counts.coords["kind"],
+            dim_name__0=[0],
+        ),
+    ).squeeze(["dim_name__0"], drop=True)
+
+    # Reshape the probability array
+    prob = np.reshape(prob.data, (len(prob.coords["sample"]), 1, 1, 1))
+    prob_stacked = np.repeat(prob, 1, 1)
+    prob_stacked = np.repeat(prob_stacked, len(true_counts.coords["time"]), 2)
+    prob_stacked = np.repeat(prob_stacked, len(true_counts.coords["kind"]), 3)
+
+    # Calculate the mean and standard deviation by multiplying the predictions with the associated probability
+    mean = (res * prob_stacked).sum("sample")
+    std = np.sqrt(((res - mean) ** 2 * prob).sum("sample"))
+
+    # Add a type to the true counts to allow concatenation
+    true_counts = true_counts.expand_dims({"type": ["true_counts"]}).squeeze(
+        "dim_name__0", drop=True
+    )
+
+    mean = xr.concat([mean, true_counts, mode_data], dim="type")
+    std = xr.concat([std, 0 * true_counts, 0 * mode_data], dim="type")
+
+    data = xr.Dataset(data_vars=dict(mean=mean, std=std))
+
+    return data
+
+
+@is_operation("SIR_densities_from_marginals")
+def SIR_densities_from_marginals(
+    data: xr.Dataset, *, num_samples: int, true_counts: xr.Dataset, cfg: dict
+) -> xr.Dataset:
+    return _densities_from_marginals(
+        data,
+        models.SIR.generate_smooth_data,
+        num_samples=num_samples,
+        true_counts=true_counts,
+        cfg=cfg,
+    )
+
+
+@is_operation("SIR_densities_from_joint")
+def SIR_densities_from_joint(
+    data: xr.Dataset, prob: xr.Dataset, *, true_counts: xr.Dataset, cfg: dict
+) -> xr.Dataset:
+
+    return _densities_from_joint(
+        data, prob, models.SIR.generate_smooth_data, true_counts=true_counts, cfg=cfg
+    )

--- a/model_plots/__init__.py
+++ b/model_plots/__init__.py
@@ -28,3 +28,4 @@ register_operation(name="xr.where", func=xr.where)
 register_operation(name=".idxmax", func=lambda d, *a, **k: d.idxmax(*a, **k))
 register_operation(name=".stack", func=lambda d, *a, **k: d.stack(*a, **k))
 from .data_ops import *
+from .SIR_trajectories_from_densities import *

--- a/models/SIR/DataGeneration.py
+++ b/models/SIR/DataGeneration.py
@@ -17,6 +17,7 @@ def generate_data_from_ABM(
     kinds=None,
     counts=None,
     write_init_state: bool = True,
+    **__,
 ):
     """
     Runs the ABM for n iterations and writes out the data, if datasets are passed.
@@ -88,6 +89,7 @@ def generate_smooth_data(
     counts=None,
     write_init_state: bool = True,
     requires_grad: bool = False,
+    **__,
 ):
 
     """
@@ -110,10 +112,11 @@ def generate_smooth_data(
     )
 
     # Write out the initial state if required
-    if write_init_state and counts:
+    if write_init_state:
         data[0] = init_state
-        counts.resize(counts.shape[0] + 1, axis=0)
-        counts[-1, :] = init_state
+        if counts:
+            counts.resize(counts.shape[0] + 1, axis=0)
+            counts[-1, :] = init_state
 
     current_state = init_state.clone()
     current_state.requires_grad = requires_grad
@@ -131,7 +134,6 @@ def generate_smooth_data(
                 torch.tensor([0, tau]),
             ]
         )
-
         current_state = torch.relu(
             current_state
             + torch.matmul(
@@ -172,7 +174,7 @@ def get_SIR_data(*, data_cfg: dict, h5group: h5.Group, write_init_state: bool = 
                 dtype=float,
             )
 
-            dset_true_counts.attrs["dim_names"] = ["time", "kind", "kinds"]
+            dset_true_counts.attrs["dim_names"] = ["time", "kind", "dim_name__0"]
             dset_true_counts.attrs["coords_mode__time"] = "trivial"
             dset_true_counts.attrs["coords_mode__kind"] = "values"
             dset_true_counts.attrs["coords__kind"] = [
@@ -180,8 +182,7 @@ def get_SIR_data(*, data_cfg: dict, h5group: h5.Group, write_init_state: bool = 
                 "infected",
                 "recovered",
             ]
-            dset_true_counts.attrs["coords_mode__kinds"] = "values"
-            dset_true_counts.attrs["coords__kinds"] = ["kind"]
+            dset_true_counts.attrs["coords_mode__dim_name__0"] = "trivial"
 
             dset_true_counts[:, :, :] = data
 
@@ -199,7 +200,7 @@ def get_SIR_data(*, data_cfg: dict, h5group: h5.Group, write_init_state: bool = 
             dtype=float,
         )
 
-        dset_true_counts.attrs["dim_names"] = ["time", "kind", "kinds"]
+        dset_true_counts.attrs["dim_names"] = ["time", "kind", "dim_name__0"]
         dset_true_counts.attrs["coords_mode__time"] = "trivial"
         dset_true_counts.attrs["coords_mode__kind"] = "values"
         dset_true_counts.attrs["coords__kind"] = [
@@ -207,8 +208,7 @@ def get_SIR_data(*, data_cfg: dict, h5group: h5.Group, write_init_state: bool = 
             "infected",
             "recovered",
         ]
-        dset_true_counts.attrs["coords_mode__kinds"] = "values"
-        dset_true_counts.attrs["coords__kinds"] = ["kind"]
+        dset_true_counts.attrs["coords_mode__dim_name__0"] = "trivial"
 
         # --- Generate the data ----------------------------------------------------------------------------------------
         type = data_cfg["synthetic_data"]["type"]

--- a/models/SIR/SIR_base_plots.yml
+++ b/models/SIR/SIR_base_plots.yml
@@ -188,17 +188,17 @@ predictions:
     - .plot.facet_grid.line
   select:
     data:
-      path: predicted_infection_rate
+      path: parameters
       transform:
         - .data: [ !dag_prev ]
   x: time
+  col: parameter
+  sharey: False
   style:
     figure.figsize: [ *half_width, *half_width ]
   helpers:
     set_labels:
       x: iteration
-#    set_scales:
-#      x: log
 
 # Two-dimensional density
 loss_density:
@@ -207,10 +207,14 @@ loss_density:
     - .plot.facet_grid.scatter
   style:
     figure.figsize: [ *half_width, *fifth_width ]
+  dag_options:
+    define:
+      parameter_idx: 0
   select:
-    param1:
-      path: predicted_infection_rate
+    parameter:
+      path: parameters
       transform:
+        - .isel: [!dag_prev , {parameter: !dag_tag parameter_idx}]
         - .squeeze_with_drop: [!dag_prev ]
     loss:
       path: loss
@@ -222,10 +226,10 @@ loss_density:
     - xr.Dataset:
       kwargs:
         data_vars:
-          param1: !dag_tag param1
+          parameter: !dag_tag parameter
           loss: !dag_tag loss
       tag: data
-  x: param1
+  x: parameter
   hue: loss
   y: loss
   s: 1
@@ -245,10 +249,14 @@ marginals:
   plot_func: plot_prob_density
   style:
     figure.figsize: [ *half_width, *half_width ]
+  dag_options:
+    define:
+      parameter_idx: 0
   select:
-    param1:
-      path: predicted_infection_rate
+    param:
+      path: parameters
       transform:
+        - .isel: [ !dag_prev , { 'parameter': !dag_tag parameter_idx } ]
         - .squeeze_with_drop: [ !dag_prev ]
     loss:
       path: loss
@@ -257,21 +265,150 @@ marginals:
         - log10: [ !dag_prev ]
         - mul: [ !dag_prev , -1 ]
         - np.exp: [!dag_prev ]
+    true_values:
+      path: ../../cfg
+      transform:
+        - recursive_getitem: [ !dag_prev , ['SIR', 'Data', 'synthetic_data' ] ]
   transform:
+    - .coords: [!dag_tag param, 'parameter']
+    - .item: [!dag_prev ]
+      tag: parameter_name
+    - getitem: [!dag_prev , !slice [2, ~]]
+      tag: compartment
     - xr.Dataset:
-      kwargs:
-        data_vars:
-          param1: !dag_tag param1
-          loss: !dag_tag loss
+      - x: !dag_tag param
+        p: !dag_tag loss
     - compute_marginals: [ !dag_prev ]
       kwargs:
         bins: 200
-        x: param1
-        p: loss
+        x: x
+        p: p
       tag: data
+    - mode: [ !dag_tag data]
+      kwargs:
+        p: p
+    - getitem: [!dag_prev , 'x']
+    - .format: [ '{:.2f}', !dag_prev ]
+      tag: mode
+    - mean: [ !dag_tag data ]
+      kwargs:
+        x: x
+        p: p
+    - getitem: [!dag_prev , 'mean']
+      tag: mean
+    - std: [ !dag_tag data ]
+      kwargs:
+        x: x
+        p: p
+    - getitem: [!dag_prev , 'std']
+    - .format: [ '{:.2f} ± {:.2f}', !dag_tag mean, !dag_prev ]
+      tag: info_str
+    - getitem: [!dag_tag true_values, !dag_tag parameter_name]
+      allow_failure: silent
+      fallback: -1
+      tag: true_val
   x: x
   y: p
   color: *darkblue
   smooth_kwargs:
     enabled: true
-    sigma: 2.0
+    sigma: 3.0
+  info_box_labels:
+    info_str: '$\mathrm{mean}$'
+    mode: '$\mathrm{mode}$'
+  helpers:
+    set_labels:
+      x: !dag_result parameter_name
+    set_hv_lines:
+      vlines:
+        - pos: !dag_result true_val
+          color: *red
+          linestyle: dotted
+
+# Multiverse marginals, sweeping over seed
+marginals_mv:
+  expected_multiverse_ndim: [1]
+  based_on: .creator.multiverse
+  module: model_plots.HarrisWilson
+  plot_func: plot_prob_density
+  compute_only: [data, info_str, mode, true_val]
+  file_ext: pdf
+  dag_options:
+    define:
+      parameter_idx: 0
+  select_and_combine:
+    fields:
+      true_val_dict:
+        path: ../../cfg
+        transform:
+          - recursive_getitem: [!dag_prev , ['SIR', 'Data', 'synthetic_data']]
+        subspace:
+          seed: [0]
+      param:
+        path: parameters
+        transform:
+          - .isel: [!dag_prev , {'parameter': !dag_tag parameter_idx}]
+          - .squeeze_with_drop: [!dag_prev ]
+      loss:
+        path: loss
+        transform:
+          - np.maximum: [ !dag_prev , *loss_limit ]
+          - log10: [ !dag_prev ]
+          - mul: [ !dag_prev , -1 ]
+          - np.exp: [!dag_prev ]
+  transform:
+    - getitem: [!dag_tag true_val_dict, 0]
+    - .item: [!dag_prev ]
+      tag: true_values
+    - .coords: [!dag_tag param, 'parameter']
+    - .item: [!dag_prev ]
+      tag: parameter_name
+    - xr.Dataset:
+      - x: !dag_tag param
+        p: !dag_tag loss
+    - compute_marginals: [ !dag_prev ]
+      kwargs:
+        bins: 200
+        x: x
+        p: p
+      tag: data
+    - mode: [ !dag_tag data]
+      kwargs:
+        p: p
+    - getitem: [!dag_prev , 'x']
+    - .format: [ '{:.2f}', !dag_prev ]
+      tag: mode
+    - mean: [ !dag_tag data ]
+      kwargs:
+        x: x
+        p: p
+    - getitem: [!dag_prev , 'mean']
+      tag: mean
+    - std: [ !dag_tag data ]
+      kwargs:
+        x: x
+        p: p
+    - getitem: [!dag_prev , 'std']
+    - .format: [ '{:.2f} ± {:.2f}', !dag_tag mean, !dag_prev ]
+      tag: info_str
+    - getitem: [!dag_tag true_values, !dag_tag parameter_name]
+      allow_failure: silent
+      fallback: -1
+      tag: true_val
+  x: x
+  y: p
+  color: *darkblue
+  smooth_kwargs:
+    enabled: true
+    sigma: 3.0
+  info_box_labels:
+    info_str: '$\mathrm{mean}$'
+    mode: '$\mathrm{mode}$'
+  helpers:
+    set_labels:
+      x: !dag_result parameter_name
+    set_hv_lines:
+      vlines:
+        - pos: !dag_result true_val
+          color: *red
+          linestyle: dotted

--- a/models/SIR/SIR_cfg.yml
+++ b/models/SIR/SIR_cfg.yml
@@ -17,7 +17,7 @@ Data:
 
     # Model parameters: infection radius, infection probability, infection time
     r_infectious: !is-positive 1.0
-    p_infect: !is-probability 0.5
+    p_infect: !is-probability 0.2
     t_infectious: !is-positive 30
 
     # Agent diffusivities
@@ -26,7 +26,7 @@ Data:
     sigma_r: !is-positive-or-zero 0.15
 
     # Number of steps to run
-    num_steps: 200
+    num_steps: 100
 
 NeuralNet:
   num_layers: !is-positive-int 1

--- a/models/SIR/SIR_info.yml
+++ b/models/SIR/SIR_info.yml
@@ -25,8 +25,7 @@ paths:
 metadata:
   description: SIR model with Neural core
   long_description: >
-    This model ...
-
+    This model calibrates an SIR model of infection using a neural network.
   version: "0.1"
   author: Thomas Gaskin
   license: LGPLv3+

--- a/models/SIR/SIR_plots.yml
+++ b/models/SIR/SIR_plots.yml
@@ -21,8 +21,9 @@ _:
 
   # True parameters
   true_parameters:
-    p_infect:         &p_infect         0.3
-    t_infect:         &t_infect         14
+    p_infect:         &p_infect         0.2
+    t_infect:         &t_infect         30
+    sigma:            &sigma            0
 
 
 # ======================================================================================================================
@@ -67,148 +68,71 @@ loss:
   style:
     figure.figsize: [ *full_width, *third_width ]
 
-# Plot the predicted infection probability
-predictions/p_infectious:
-  based_on: predictions
-  helpers:
-    set_hv_lines:
-      hlines:
-        - pos: *p_infect
-          color: *yellow
-          zorder: -1
-          linestyle: dotted
-    set_labels:
-      y: ' '
-    set_legend:
-      custom_labels: ['$p_\mathrm{infect}$']
-      title: ~
-      loc: 'best'
-    set_texts:
-      texts:
-        - x: 0.33
-          y: *p_infect
-          s: '$p_i$'
-          color: *color_p_i
-          bbox: &textbox
-            facecolor: white
-            linewidth: 0
-            alpha: 1.0
-            boxstyle: circle
-            pad: 0.4
-    set_limits:
-      y: [0, 1]
-
-predictions/t_infectious:
+# Plot the evolution of the parameters
+predictions:
   based_on: predictions
   select:
-      data:
-        path: predicted_infection_time
-        transform:
-          - .data: [ !dag_prev ]
+    data:
+      transform:
+        - .sel: [ !dag_prev , {time: !slice [~, ~, 100]}]
   helpers:
-    set_hv_lines:
-      hlines:
-        - pos: *t_infect
-          color: *yellow
-          zorder: -1
-          linestyle: dotted
+    setup_figure:
+      ncols: 3
+      nrows: 1
+    axis_specific:
+      p_infect:
+        axis: [0, 0]
+        set_hv_lines:
+          hlines:
+            - pos: *p_infect
+              color: *red
+              zorder: 10
+              linestyle: dotted
+      t_infect:
+        axis: [ 1, 0 ]
+        set_hv_lines:
+          hlines:
+            - pos: *t_infect
+              color: *red
+              zorder: 10
+              linestyle: dotted
+      sigma:
+        axis: [ 2, 0 ]
+        set_hv_lines:
+          hlines:
+            - pos: *sigma
+              color: *red
+              zorder: 10
+              linestyle: dotted
     set_labels:
       y: ' '
-    set_legend:
-      custom_labels: ['$t_\mathrm{infect}$']
-      title: ~
-      loc: 'best'
-    set_texts:
-      texts:
-        - x: 0.33
-          y: *t_infect
-          s: '$t_i$'
-          color: *color_p_i
-          bbox:
-            <<: *textbox
 
-predictions/noise:
-  based_on: predictions
-  select:
-      data:
-        path: predicted_noise
-        transform:
-          - .data: [ !dag_prev ]
-  helpers:
-    set_labels:
-      y: ' '
-    set_legend:
-      custom_labels: ['$\sigma$']
-      title: ~
-      loc: 'best'
-
-loss_density/p_infectious:
-  based_on: loss_density
-  select:
-    param1:
-      path: predicted_infection_rate
-  helpers:
-    set_labels:
-      x: '$p_i$'
-    set_hv_lines:
-      vlines:
-        - pos: *p_infect
-          color: *red
-          zorder: 1
-          linestyle: dotted
-
-loss_density/t_infectious:
-  based_on: loss_density
-  select:
-    param1:
-      path: predicted_infection_time
-  helpers:
-    set_labels:
-      x: '$t_i$'
-    set_hv_lines:
-      vlines:
-        - pos: *t_infect
-          color: *red
-          zorder: 1
-          linestyle: dotted
-
-marginals/p_infectious:
+# Plot the marginals of all the parameters
+marginals: !pspace
   based_on: marginals
+  dag_options:
+    define:
+      parameter_idx: !sweep
+        default: 0
+        range: [3]
   helpers:
     set_labels:
-      x: '$p$'
-      y: '$\rho(p)$'
+      x: !coupled-sweep
+        default: '$p$'
+        values: ['$p$', '$\tau$', '$\sigma$']
+        target_name: parameter_idx
+      y: !coupled-sweep
+        default: '$\rho(p)$'
+        values: ['$\rho(p)$', '$\rho(\tau)$', '$\rho(\sigma)$']
+        target_name: parameter_idx
     set_hv_lines:
       vlines:
-        - pos: *p_infect
+        - pos: !coupled-sweep
+            default: *p_infect
+            values: [*p_infect, *t_infect, *sigma]
+            target_name: parameter_idx
           color: *red
           zorder: 1
           linestyle: dotted
   style:
     figure.figsize: [*half_width, *quarter_width]
-
-marginals/t_infectious:
-  based_on: marginals/p_infectious
-  select:
-    param1:
-      path: predicted_infection_time
-  helpers:
-    set_labels:
-      x: '$\tau$'
-      y: '$\rho(\tau)$'
-    set_hv_lines:
-      vlines:
-        - pos: *t_infect
-          color: *red
-          zorder: 1
-          linestyle: dotted
-
-marginals/noise:
-  based_on: marginals/p_infectious
-  select:
-    param1:
-      path: predicted_noise
-  helpers:
-    set_labels:
-      x: '$\sigma$'
-      y: '$\rho(\sigma)$'

--- a/models/SIR/cfgs/Predictions/eval.yml
+++ b/models/SIR/cfgs/Predictions/eval.yml
@@ -118,125 +118,124 @@ densities:
       colors: *colors
   file_ext: pdf
 
-# ======================================================================================================================
-#  ╦╔╗╔╔═╗╔═╗╔═╗╔╦╗╦╔═╗╔╗╔  ╔═╗╦═╗╔═╗╔╗
-#  ║║║║╠╣ ║╣ ║   ║ ║║ ║║║║  ╠═╝╠╦╝║ ║╠╩╗
-#  ╩╝╚╝╚  ╚═╝╚═╝ ╩ ╩╚═╝╝╚╝  ╩  ╩╚═╚═╝╚═╝
-# ======================================================================================================================
 
-p_infectious:
-  based_on: .creator.multiverse
-  module: model_plots.HarrisWilson
-  plot_func: plot_prob_density
-  compute_only: [data, info_str, mode]
-  file_ext: pdf
+# Generate densities by drawing from the joint distribution of the parameters
+densities_from_joint:
+  based_on:
+    - .creator.multiverse
+    - .plot.facet_grid.errorbands
   select_and_combine:
     fields:
-      param1:
-        path: predicted_infection_rate
-        transform:
-          - .squeeze_with_drop: [ !dag_prev ]
+      parameters:
+        path: parameters
+        transform: [.data]
       loss:
         path: loss
         transform:
-          - np.maximum: [ !dag_prev , *loss_limit ]
-          - log10: [ !dag_prev ]
           - mul: [ !dag_prev , -1 ]
-          - np.exp: [!dag_prev ]
+          - np.exp: [ !dag_prev ]
+      true_data:
+        path: true_counts
+        transform: [.data]
+      cfg:
+        path: ../../cfg
+        transform:
+          - getitem: [!dag_prev , 'SIR']
+        subspace:
+          seed: [0]
   transform:
-    - xr.Dataset:
-      - x: !dag_tag param1
-        p: !dag_tag loss
-    - compute_marginals: [ !dag_prev ]
+    # Extract the cfg
+    - .data: [!dag_tag cfg]
+    - getitem: [!dag_prev , 0]
+      tag: cfg_flattened
+
+    # Flatten the true counts
+    - .isel: [!dag_tag true_data, {seed: 0}]
+      kwargs: {drop: True}
+      tag: true_data_flattened
+
+    # Flatten the parameters
+    - flatten_dims: [ !dag_tag parameters , [ seed, time ] , sample ]
+    - .sel: [!dag_prev , {'sample': !slice [~, ~, 100]}]
+      tag: parameters_flattened
+
+    # Flatten and normalise the loss
+    - flatten_dims: [ !dag_tag loss , [ seed, time ], sample ]
+    - .sel: [ !dag_prev , { 'sample': !slice [ ~, ~, 100 ] } ]
+    - .sum: [ !dag_prev ]
+    - div: [ !dag_node -2, !dag_prev ]
+
+    # Copy the loss for each parameter
+    - SIR_densities_from_joint: [!dag_tag parameters_flattened, !dag_prev ]
       kwargs:
-        bins: 200
-        x: x
-        p: p
+        true_counts: !dag_tag true_data_flattened
+        cfg: !dag_tag cfg_flattened
+      file_cache:
+        read: True
+        write: True
       tag: data
-    - mode: [ !dag_tag data]
-      kwargs:
-        p: p
-    - getitem: [!dag_prev , 'x']
-    - .format: [ '{:.2f}', !dag_prev ]
-      tag: mode
-    - mean: [ !dag_tag data ]
-      kwargs:
-        x: x
-        p: p
-    - getitem: [!dag_prev , 'mean']
-      tag: mean
-    - std: [ !dag_tag data ]
-      kwargs:
-        x: x
-        p: p
-    - getitem: [!dag_prev , 'std']
-    - .format: [ '{:.2f} ± {:.2f}', !dag_tag mean, !dag_prev ]
-      tag: info_str
-  x: x
-  y: p
-  color: *darkblue
-  smooth_kwargs:
-    enabled: true
-    sigma: 3.0
+  x: time
+  y: mean
+  yerr: std
+  hue: type
+  col: kind
+  col_wrap: 3
+  sharey: False
+  add_legend: False
+  figsize: [ *full_width, *third_width ]
+  helpers:
+    set_labels:
+      y: ' '
+    axis_specific:
+      0:
+        axis: [0, 0]
+        set_legend:
+          use_legend: True
+          gather_from_fig: True
+          custom_labels: [mean, mode, true data]
+  style:
+    axes.prop_cycle: !format
+      fstr: "cycler('color', ['{colors[darkblue]:}', '{colors[orange]:}', '{colors[lightbrown]:}'])"
+      colors: *colors
+  file_ext: pdf
+# ======================================================================================================================
+#  ╔╦╗╔═╗╦═╗╔═╗╦╔╗╔╔═╗╦  ╔═╗
+#  ║║║╠═╣╠╦╝║ ╦║║║║╠═╣║  ╚═╗
+#  ╩ ╩╩ ╩╩╚═╚═╝╩╝╚╝╩ ╩╩═╝╚═╝
+# ======================================================================================================================
+marginals: !pspace
+  based_on: marginals_mv
+  dag_options:
+    define:
+      parameter_idx: !sweep
+        default: 0
+        range: [3]
+  select_and_combine:
+    fields:
+      true_val_dict:
+        transform:
+          - dict:
+              p_infect: 0.2
+              t_infectious: 14
+              sigma: 0
+  style:
+    figure.figsize: [ *third_width, *quarter_width ]
   info_box_labels:
-    info_str: 'E[$\hat{\beta}$]'
+    info_str: !coupled-sweep
+      default: '$\mathrm{mean}$'
+      values: ['$E[\hat{\beta}]$', '$E[\hat{\tau}]$', '$E[\hat{\sigma}]$']
+      target_name: parameter_idx
     mode: '$\mathrm{mode}$'
   helpers:
     set_labels:
-      x: '$\beta$'
-    set_hv_lines:
-      vlines:
-        - pos: *p_infectious
-          color: *red
-          linestyle: dotted
+      x: !coupled-sweep
+        default: '$x$'
+        values: ['$\beta$', '$\tau$', '$\sigma$']
+        target_name: parameter_idx
     set_limits:
-      x: [min, 0.6]
-  style:
-    figure.figsize: [ *third_width, *quarter_width ]
-
-# ======================================================================================================================
-#  ╦╔╗╔╔═╗╔═╗╔═╗╔╦╗╦╔═╗╔╗╔  ╔╦╗╦╔╦╗╔═╗
-#  ║║║║╠╣ ║╣ ║   ║ ║║ ║║║║   ║ ║║║║║╣
-#  ╩╝╚╝╚  ╚═╝╚═╝ ╩ ╩╚═╝╝╚╝   ╩ ╩╩ ╩╚═╝
-# ======================================================================================================================
-
-t_infectious:
-  based_on: p_infectious
-  select_and_combine:
-    fields:
-      param1:
-        path: predicted_infection_time
-  info_box_labels:
-    info_str: 'E[$\hat{\tau}$]'
-  helpers:
-    set_labels:
-      x: '$\tau$'
-    set_hv_lines:
-      vlines:
-        - pos: *t_infectious
-          color: *red
-          linestyle: dotted
-    set_limits:
-      x: [ 5, max ]
-
-# ======================================================================================================================
-#  ╔╗╔╔═╗╦╔═╗╔═╗
-#  ║║║║ ║║╚═╗║╣
-#  ╝╚╝╚═╝╩╚═╝╚═╝
-# ======================================================================================================================
-
-noise:
-  based_on: p_infectious
-  select_and_combine:
-    fields:
-      param1:
-        path: predicted_noise
-  info_box_labels:
-    info_str: 'E[$\hat{\sigma}$]'
-  helpers:
-    set_labels:
-      x: '$\sigma$'
-    set_hv_lines:
-      vlines: ~
-    set_limits:
-      x: [ 0, 0.6 ]
+      x: !coupled-sweep
+        default: [0, ~]
+        values: [[min, 0.6], [5, max], [0, 0.6]]
+        target_name: parameter_idx
+  smooth_kwargs:
+    sigma: 3.0


### PR DESCRIPTION
This PR
- restructures the SIR parameters dataset into a single dataset, indexed by the parameter name
- rewrites the marginal density plots as sweep plots over the parameter name
- adds `density_from_joint` and `density_from_marginals` plots
- restructures the SIR default plots
- reduces the default number of epochs