### PR TITLE
Initialisation to prior

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ providing the path to that dataset, like so:
 utopya eval HarrisWilson path/to/output/folder --cfg-set <name_of_cfg_set>
 ```
 ## How to adjust the neural net configuration
+### General architecture
 You can vary the size of the neural net and the activation functions
 right from the config. The size of the input layer is inferred from
 the data passed to it, and the size of the output layer is
@@ -260,6 +261,7 @@ which is initialised uniformly at random on [0, 4]. Layer-specific settings are 
 You can also set the bias initialisation interval to `default`: this will initialise the bias using the [PyTorch default](https://github.com/pytorch/pytorch/blob/9a575e77ca8a0be7a3f3625c4dfdc6321d2a0c2d/torch/nn/modules/linear.py#L72)
 Xavier uniform distribution.
 
+### Activation functions
 Any [PyTorch activation function](https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity)
 is supported, such as ``relu``, ``linear``, ``tanh``, ``sigmoid``, etc. Some activation functions take arguments and
 keyword arguments; these can be provided like this:
@@ -278,6 +280,34 @@ NeuralNet:
         # any kwargs here ...
 ```
 
+### Specifying the prior on the output
+For many applications, you will want control over the prior distribution of the parameters. To this
+end, you can add a `prior` entry that gives a distribution over the parameters you wish to learn:
+```yaml
+NeuralNet:
+  prior:
+    distribution: uniform
+    parameters:
+      lower: 0
+      upper: 2
+```
+This will train the neural network to initially output values uniformly within [0, 2], for all
+parameters you wish to learn. If you want individual parameters to have their own priors, you can do so by passing a
+list as the argument to `prior`. For instance, assume you wish to learn 2 parameters; the configuration entry then could
+be:
+```yaml
+NeuralNet:
+  prior:
+    - distribution: normal
+      parameters:
+        mean: 0.5
+        std: 0.1
+    - distribution: uniform
+      parameters:
+        lower: 0
+        upper: 5
+```
+This will initialise each parameter with a separate prior.
 ## Training settings
 You can modify the training settings, such as the batch size or the training device, from the
 `Training` entry of the config:

--- a/include/utils.py
+++ b/include/utils.py
@@ -1,44 +1,86 @@
+from typing import Union
+
 import torch
 
 """ General utility functions """
 
 
 def random_tensor(
-    *, distribution: str, parameters: dict, size: tuple, device: str = "cpu", **__
+    cfg: Union[dict, list], *, size: tuple = None, device: str = "cpu", **__
 ) -> torch.Tensor:
+    """Generates a multi-dimensional random tensor. Each entry can be initialised separately, or a common
+    initialisation configuration is used for each entry. For instance, the configuration
 
-    """Generates a random tensor according to a distribution.
+    .. code-block::
 
-    :param distribution: the type of distribution. Can be 'uniform' or 'normal'.
-    :param parameters: the parameters relevant to the respective distribution
-    :param size: the size of the random tensor
+        cfg:
+            distribution: uniform
+            parameters:
+                lower: 0
+                upper: 1
+
+    together with `size: (2, 2)` will initialise a 2x2 matrix with entries drawn from a uniform distribution on
+    [0, 1]. The configuration
+
+    .. code-block::
+
+        cfg:
+            - distribution: uniform
+              parameters:
+                 lower: 0
+                 upper: 1
+            - distribution: normal
+              parameters:
+                mean: 0.5
+                std: 0.1
+
+    will initialise a (2, 1) tensor with entries drawn from different distributions.
+
+    :param cfg: the configuration entry containing the initialisation data
+    :param size (optional): the size of the tensor, in case the configuration is not a list
     :param device: the device onto which to load the data
     :param __: additional kwargs (ignored)
     :return: the tensor of random variables
     """
 
-    # Uniform distribution in an interval
-    if distribution == "uniform":
+    def _random_tensor_1d(
+        *, distribution: str, parameters: dict, s: tuple = (1,), **__
+    ) -> torch.Tensor:
 
-        l, u = parameters.get("lower"), parameters.get("upper")
-        if l > u:
-            raise ValueError(
-                f"Upper bound must be greater or equal to lower bound; got {l} and {u}!"
+        """Generates a random tensor according to a distribution.
+
+        :param distribution: the type of distribution. Can be 'uniform' or 'normal'.
+        :param parameters: the parameters relevant to the respective distribution
+        :param s: the size of the random tensor
+        """
+
+        # Uniform distribution in an interval
+        if distribution == "uniform":
+
+            l, u = parameters.get("lower"), parameters.get("upper")
+            if l > u:
+                raise ValueError(
+                    f"Upper bound must be greater or equal to lower bound; got {l} and {u}!"
+                )
+
+            return torch.tensor((u - l), dtype=torch.float) * torch.rand(
+                s, dtype=torch.float, device=device
+            ) + torch.tensor(l, dtype=torch.float)
+
+        # Normal distribution
+        elif distribution == "normal":
+            return torch.normal(
+                parameters.get("mean"),
+                parameters.get("std"),
+                size=s,
+                device=device,
+                dtype=torch.float,
             )
 
-        return torch.tensor((u - l), dtype=torch.float) * torch.rand(
-            size, dtype=torch.float, device=device
-        ) + torch.tensor(l, dtype=torch.float)
+        else:
+            raise ValueError(f"Unrecognised distribution type {distribution}!")
 
-    # Normal distribution
-    elif distribution == "normal":
-        return torch.normal(
-            parameters.get("mean"),
-            parameters.get("std"),
-            size=size,
-            device=device,
-            dtype=torch.float,
-        )
-
+    if isinstance(cfg, list):
+        return torch.tensor([_random_tensor_1d(**entry) for entry in cfg]).to(device)
     else:
-        raise ValueError(f"Unrecognised distribution type {distribution}!")
+        return _random_tensor_1d(**cfg, s=size).to(device)

--- a/models/HarrisWilson/DataGeneration.py
+++ b/models/HarrisWilson/DataGeneration.py
@@ -89,7 +89,7 @@ def generate_synthetic_data(
     # Generate the initial origin sizes
     or_sizes = torch.abs(
         base.random_tensor(
-            **data_cfg.get("origin_sizes"), size=(N_origin, 1), device=device
+            data_cfg.get("origin_sizes"), size=(N_origin, 1), device=device
         )
     )
 
@@ -98,9 +98,9 @@ def generate_synthetic_data(
         -1
         * torch.abs(
             base.random_tensor(
-                **data_cfg.get("init_weights"),
+                data_cfg.get("init_weights"),
                 size=(N_origin, N_destination),
-                device=device
+                device=device,
             )
         )
     )
@@ -108,7 +108,7 @@ def generate_synthetic_data(
     # Generate the initial destination zone sizes
     init_dest_sizes = torch.abs(
         base.random_tensor(
-            **data_cfg.get("init_dest_sizes"), size=(N_destination, 1), device=device
+            data_cfg.get("init_dest_sizes"), size=(N_destination, 1), device=device
         )
     )
 

--- a/models/HarrisWilsonNW/DataGeneration.py
+++ b/models/HarrisWilsonNW/DataGeneration.py
@@ -79,7 +79,7 @@ def get_data(
 
             origin_sizes[idx, 0, :, :] = torch.abs(
                 base.random_tensor(
-                    **data_cfg.get("init_origin_sizes"), size=(1, N_origin, 1)
+                    data_cfg.get("init_origin_sizes"), size=(1, N_origin, 1)
                 )
             )
 
@@ -97,7 +97,7 @@ def get_data(
             -1
             * torch.abs(
                 base.random_tensor(
-                    **data_cfg.get("init_network_weights"),
+                    data_cfg.get("init_network_weights"),
                     size=(N_origin, N_destination),
                 )
             )
@@ -137,7 +137,7 @@ def get_data(
             # Generate the initial destination zone sizes
             destination_sizes[idx, 0, :, :] = torch.abs(
                 base.random_tensor(
-                    **data_cfg.get("init_dest_sizes"),
+                    data_cfg.get("init_dest_sizes"),
                     size=(data_cfg["N_destination"], 1),
                 )
             )

--- a/models/Kuramoto/DataGeneration.py
+++ b/models/Kuramoto/DataGeneration.py
@@ -127,7 +127,7 @@ def get_data(
 
         # Generate a time series of i.i.d distributed eigenfrequencies
         eigen_frequencies = base.random_tensor(
-            **data_cfg.get("eigen_frequencies"),
+            data_cfg.get("eigen_frequencies"),
             size=(training_set_size, 1, N, 1),
             device=device,
         )
@@ -161,7 +161,7 @@ def get_data(
         for idx in range(training_set_size):
 
             training_data[idx, 0, :, :] = base.random_tensor(
-                **data_cfg.get("init_phases"), size=(N, 1), device=device
+                data_cfg.get("init_phases"), size=(N, 1), device=device
             )
 
             # For the second-order dynamics, the initial velocities must also be given

--- a/tests/cfgs/neural_net.yml
+++ b/tests/cfgs/neural_net.yml
@@ -166,3 +166,20 @@ Default_bias2:
       -1: default
   optimiser: SGD
   learning_rate: 0.1
+
+# Initialise the NN to a prior
+Prior1:
+  num_layers: 2
+  nodes_per_layer:
+    default: 10
+  activation_funcs:
+    default: sigmoid
+  biases:
+    default: [0, 1]
+  prior:
+    distribution: uniform
+    parameters:
+      lower: 0
+      upper: 2
+  prior_tol: 1e-10
+  prior_max_iter: 5000

--- a/tests/cfgs/test_utils.yml
+++ b/tests/cfgs/test_utils.yml
@@ -31,3 +31,37 @@ normal:
   parameters:
     mean: 0.5
     std: 3.1
+
+# Multi-dimensional with different initialisations
+multi1:
+  cfg:
+    - distribution: uniform
+      parameters:
+        lower: 0
+        upper: 1
+    - distribution: normal
+      parameters:
+        mean: 0.5
+        std: 0.1
+    - distribution: uniform
+      parameters:
+        lower: -1
+        upper: 2
+
+# This should fail
+multi2:
+  cfg:
+    - distribution: uniform
+      parameters:
+        lower: 0
+        upper: 1
+    - distribution: normal
+      parameters:
+        mean: 0.5
+        std: 0.1
+    - distribution: uniform
+      parameters:
+        lower: 4
+        upper: 2
+  _raises: ValueError
+  _match: Upper bound must be greater or equal to lower bound

--- a/tests/core/test_neural_net.py
+++ b/tests/core/test_neural_net.py
@@ -162,3 +162,32 @@ def test_training():
                     .numpy()
                 )
                 assert current_loss != previous_loss
+
+
+# Test the model outputs values according to the prior
+def test_prior():
+    def _test_entry(cfg, tensor):
+
+        if cfg["distribution"] == "uniform":
+            assert cfg["parameters"]["lower"] <= tensor <= cfg["parameters"]["upper"]
+
+    tested = False
+    for _, config in test_cfg.items():
+
+        net = nn.NeuralNet(input_size=input_size, output_size=output_size, **config)
+
+        if net.prior_distribution is not None:
+            tested = True
+
+            t = net(
+                torch.rand(
+                    input_size,
+                )
+            )
+
+            for _ in range(len(t)):
+                if isinstance(net.prior_distribution, dict):
+                    _test_entry(net.prior_distribution, t[_])
+                else:
+                    _test_entry(net.prior_distribution[_], t[_])
+    assert tested

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -3,6 +3,7 @@ from builtins import *
 from os.path import dirname as up
 
 import pytest
+import torch
 from dantro._import_tools import import_module_from_path
 from pkg_resources import resource_filename
 
@@ -18,6 +19,11 @@ test_cfg = load_yml(CFG_FILENAME)
 
 
 def test_random_tensor():
+    def _test_entry(cfg, tensor):
+
+        if cfg["distribution"] == "uniform":
+            assert cfg["parameters"]["lower"] <= tensor <= cfg["parameters"]["upper"]
+
     for _, config in test_cfg.items():
 
         _raises = config.pop("_raises", False)
@@ -26,38 +32,32 @@ def test_random_tensor():
         _exp_warning = UserWarning if not isinstance(_warns, str) else globals()[_warns]
         _match = config.pop("_match", " ")
 
+        cfg = config if "cfg" not in config.keys() else config.get("cfg")
+
         if not _raises:
 
-            t = utils.random_tensor(**config, size=(1,))
+            for size in [(1,), (4, 4, 4)]:
+                t = utils.random_tensor(cfg, size=size)
 
-            if config.get("distribution") == "uniform":
-                assert (
-                    config.get("parameters").get("lower")
-                    <= t
-                    <= config.get("parameters").get("upper")
-                )
+                if isinstance(cfg, list):
+                    assert len(t) == len(cfg)
+                else:
+                    assert t.shape == torch.Size(size)
 
-            t = utils.random_tensor(**config, size=(4, 4, 4))
-
-            if config.get("distribution") == "uniform":
-                assert all(
-                    [
-                        config.get("parameters").get("lower")
-                        <= item
-                        <= config.get("parameters").get("upper")
-                        for item in t.flatten()
-                    ]
-                )
-
-            assert t.shape == (4, 4, 4)
+                t = torch.flatten(t)
+                for _ in range(len(t)):
+                    if isinstance(cfg, dict):
+                        _test_entry(cfg, t[_])
+                    else:
+                        _test_entry(cfg[_], t[_])
 
         if not _raises and not _warns:
-            t = utils.random_tensor(**config, size=(1,))
+            _ = utils.random_tensor(cfg, size=(1,))
 
         elif _warns and not _raises:
             with pytest.warns(_exp_warning, match=_match):
-                t = utils.random_tensor(**config, size=(1,))
+                _ = utils.random_tensor(cfg, size=(1,))
 
         elif _raises and not _warns:
             with pytest.raises(_exp_exc, match=_match):
-                t = utils.random_tensor(**config, size=(1,))
+                _ = utils.random_tensor(cfg, size=(1,))


### PR DESCRIPTION
This PR
- allows explicitly initialising the neural network to a prior, rather than doing so manually by adjusting the biases
- allows initialising each entry of a random tensor individually with a specific distribution