### PR TITLE
Increase Python compatibility

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,17 +19,20 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip' # caching pip dependencies
       - name: Set up Python 3.11
         uses: actions/setup-python@v3
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip' # caching pip dependencies
-      - name: Set up Python 3.11
+      - name: Set up Python
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 
 [![CI](https://github.com/ThGaskin/NeuralABM/actions/workflows/pytest.yml/badge.svg)](https://github.com/ThGaskin/NeuralABM/actions/workflows/pytest.yml)
 [![coverage badge](https://thgaskin.github.io/NeuralABM/coverage-badge.svg)](https://thgaskin.github.io/NeuralABM)
-[![Python 3.6](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
+[![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/downloads/release/python-380/)
+[![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/downloads/release/python-390/)
+[![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
+[![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
 This project combines multi-agent models with a neural core to estimate marginal densities on ODE parameters
 (including adjacency matrices) from data. The project

--- a/model_plots/_op_utils.py
+++ b/model_plots/_op_utils.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Sequence, Union
+from typing import Sequence, Union, Tuple
 
 import numpy as np
 import xarray as xr
@@ -81,7 +81,7 @@ def apply_along_dim(func):
 
 def _hist(
     obj, *, normalize: Union[bool, float] = None, **kwargs
-) -> tuple[np.ndarray, np.ndarray]:
+) -> Tuple[np.ndarray, np.ndarray]:
     """Applies ``numpy.histogram`` along an axis of an object and returns the counts and bin centres.
     If specified, the counts are normalised. Returns the counts and bin centres (not bin edges!)
     :param obj: data to bin
@@ -138,7 +138,7 @@ def _get_hist_bins_ranges(ds, bins, ranges, axis):
 
 def _interpolate(
     _p: xr.DataArray, _q: xr.DataArray
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Interpolates two one-dimensional densities _p and _q onto their common support, with the mesh size given by the sum of the
     individual mesh sizes. ``_p`` and ``_q`` must be one-dimensional."""
 

--- a/model_plots/data_ops.py
+++ b/model_plots/data_ops.py
@@ -379,7 +379,7 @@ def hist(
     if use_bins_as_coords:
         sel = [0] * len(np.shape(bin_centres))
         sel[axis] = None
-        bin_centres = bin_centres[*sel].flatten()
+        bin_centres = bin_centres[tuple(sel)].flatten()
         coords.update({dim: bin_centres})
 
         res = xr.DataArray(

--- a/tests/cfgs/SIR_Dynamics.yml
+++ b/tests/cfgs/SIR_Dynamics.yml
@@ -3,9 +3,9 @@ periodic:
   N: 100
   space: [10, 10]
   r_infectious: 3
-  p_infect: 0.2
-  t_infectious: 5
-  num_steps: 10
+  p_infect: 0.5
+  t_infectious: 10
+  num_steps: 20
   sigma: 0.1
   sigma_s: 0.5
   sigma_i: 0.5
@@ -16,9 +16,9 @@ dynamics:
   N: 100
   space: [10, 10]
   r_infectious: 3
-  p_infect: 0.2
-  t_infectious: 5
-  num_steps: 10
+  p_infect: 0.5
+  t_infectious: 10
+  num_steps: 20
   sigma: 0.1
   sigma_s: 0.02
   sigma_i: 0.01


### PR DESCRIPTION
Currently, `NeuralABM` requires Python 3.11. This package increases python compatibility to older versions. Since `PyTorch` does not yet support 3.12, 3.11 is the highest possible version.