### PR TITLE
Add Windows installation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ pip install git+https://gitlab.com/utopia-project/utopya@89-allow-exec-prefix
 
 Be aware that development on the utopya Windows dev branch is ongoing; if you run into any problems, please file an [issue](https://gitlab.com/utopia-project/utopya/-/issues/new). 
 
+Next, in `cfg/multiverse_project_cfg.yml`, uncomment the following line:
+
+```yaml
+executable_control:
+   prefix: !if-windows-else [[python], ~]
+```
+
 Lastly, you must change the default encoding to utf-8 on Windows; in the Control Panel, navigate to the 
 Regional Settings, go to the 'Administrative' tab, click 'Change system locale' under 'Language for non-Unicode programs',
 and check the 'Beta: Use Unicode UTF-8 for worldwide language support option'. See [here](https://stackoverflow.com/questions/57131654/using-utf-8-encoding-chcp-65001-in-command-prompt-windows-powershell-window/57134096#57134096)

--- a/cfg/multiverse_project_cfg.yml
+++ b/cfg/multiverse_project_cfg.yml
@@ -6,7 +6,8 @@ executable_control:
   run_from_tmpdir: false
 
   # Default prefix for windows operations
-  prefix: !if-windows-else [[python], ~]
+  # Uncomment on Windows
+  # prefix: !if-windows-else [[python], ~]
 
 parameter_space:
   num_epochs: 100


### PR DESCRIPTION
Adds the `prefix` setting to the config, which however must still be manually uncommented on Windows until the utopya dev branch is merged.