### PR TITLE
Fix images in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,13 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/8fd28ab8-e471-4600-abf5-9fcbb9cfc4a6" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/14724451/marginals_all.pdf" width="49%"> 
-<img width="656" alt="Marginals" src="https://github.com/ThGaskin/NeuralABM/files/14724453/predictions"> <img src="https://github.com/ThGaskin/NeuralABM/files/14724454/densities_from_joint.pdf" width="49%">
+
+<img src="https://github.com/ThGaskin/NeuralABM/files/14724527/predictions.pdf">
+
+
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/476c99e3-a9f5-443f-8c27-f2ea16e13e4d">
+
+
 <img width="656" alt="Screenshot 2024-01-21 at 00 50 07" src="https://github.com/ThGaskin/NeuralABM/assets/22022754/68239667-febd-4611-aff6-9694ced7c1ed">
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-![]("https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b") <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width=49%> 
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width=49%> 
 
 <img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width=49%>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-<picture> <source srcset="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b"> </picture>
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b" />
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/4b786ca5-73df-44a0-92d3-2e4732ef25de" width=49%>
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/4b786ca5-73df-44a0-92d3-2e4732ef25de" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/c2701e7a-c5d2-4afb-907e-2772aae69b3c" width=49%>
 
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
 <img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/8fd28ab8-e471-4600-abf5-9fcbb9cfc4a6" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/14724451/marginals_all.pdf" width="49%"> 
-<img src="https://github.com/ThGaskin/NeuralABM/files/14724453/predictions.pdf" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/14724454/densities_from_joint.pdf" width="49%">
+<img width="656" alt="Marginals" src="https://github.com/ThGaskin/NeuralABM/files/14724453/predictions"> <img src="https://github.com/ThGaskin/NeuralABM/files/14724454/densities_from_joint.pdf" width="49%">
 <img width="656" alt="Screenshot 2024-01-21 at 00 50 07" src="https://github.com/ThGaskin/NeuralABM/assets/22022754/68239667-febd-4611-aff6-9694ced7c1ed">
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b" width="200"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width="49%"> 
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width="49%"> 
 
 <img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width="49%">
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b"/> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width="49%"> 
 
-<img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width="49%">
+<img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width="49%">
 
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-![]("https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b") 
-![](https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf")
+![]("https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b") <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width=49%> 
 
 <img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width=49%>
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,8 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/4b786ca5-73df-44a0-92d3-2e4732ef25de" width=49%>
 
-<img src="https://github.com/ThGaskin/NeuralABM/files/14724527/predictions.pdf">
-
-
-<img alt="miao" src="https://github.com/ThGaskin/NeuralABM/assets/22022754/476c99e3-a9f5-443f-8c27-f2ea16e13e4d">
-
-
-<img width="656" alt="Screenshot 2024-01-21 at 00 50 07" src="https://github.com/ThGaskin/NeuralABM/assets/22022754/68239667-febd-4611-aff6-9694ced7c1ed">
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-<img width="656" alt="Screenshot 2024-01-21 at 00 50 07" src="https://github.com/ThGaskin/NeuralABM/assets/22022754/ba5d7f52-8c88-49a4-958e-d3a89752b30b">
-
-<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b" />
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/8fd28ab8-e471-4600-abf5-9fcbb9cfc4a6" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/14724451/marginals_all.pdf" width="49%"> 
+<img src="https://github.com/ThGaskin/NeuralABM/files/14724453/predictions.pdf" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/14724454/densities_from_joint.pdf" width="49%">
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
+<img width="656" alt="Screenshot 2024-01-21 at 00 50 07" src="https://github.com/ThGaskin/NeuralABM/assets/22022754/ba5d7f52-8c88-49a4-958e-d3a89752b30b">
+
 <img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b" />
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width=49%> 
+![]("https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b") <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width=49%> 
 
 <img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width=49%>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-![]("https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b") <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width=49%> 
+![]("https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b") 
+![](https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf")
 
 <img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width=49%>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width="49%"> 
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b"/> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width="49%"> 
 
 <img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width="49%">
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-<img src="https://private-user-images.githubusercontent.com/22022754/294950846-e0bf61c7-4fe1-4234-b480-02d1f8efff6b.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTExMTg1MjIsIm5iZiI6MTcxMTExODIyMiwicGF0aCI6Ii8yMjAyMjc1NC8yOTQ5NTA4NDYtZTBiZjYxYzctNGZlMS00MjM0LWI0ODAtMDJkMWY4ZWZmZjZiLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDAzMjIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwMzIyVDE0MzcwMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTk4YWI4MzE0MzAwYzRlZmZmMWM0NzUzNDFlYjQ3YzAzNjZmMDkwNzkwZDBjZWU3ZDA3ZDgzYmE5NWJjYTc0ZGMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.PBG2XbeZK0pJDpIHJ1dVk4RySojqr8QgqfqCrKjYU10"/> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width="49%"> 
-
-<img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width="49%">
-
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b"/> 
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width=49%> 
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width="49%"> 
 
-<img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width=49%>
+<img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width="49%">
 
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
 ![]("https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b") 
-![](https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf")
+![]("https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf")
 
 <img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width=49%>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b"/> 
+<picture> <source srcset="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b"> </picture>
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
 ![]("https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b") 
-![]("https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf")
+![](https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf")
 
 <img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width=49%>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width="49%"> 
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b" width="200"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width="49%"> 
 
 <img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width="49%">
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 <img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/8fd28ab8-e471-4600-abf5-9fcbb9cfc4a6" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/14724451/marginals_all.pdf" width="49%"> 
 <img src="https://github.com/ThGaskin/NeuralABM/files/14724453/predictions.pdf" width="49%"> <img src="https://github.com/ThGaskin/NeuralABM/files/14724454/densities_from_joint.pdf" width="49%">
+<img width="656" alt="Screenshot 2024-01-21 at 00 50 07" src="https://github.com/ThGaskin/NeuralABM/assets/22022754/68239667-febd-4611-aff6-9694ced7c1ed">
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <img src="https://github.com/ThGaskin/NeuralABM/files/14724527/predictions.pdf">
 
 
-<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/476c99e3-a9f5-443f-8c27-f2ea16e13e4d">
+<img alt="miao" src="https://github.com/ThGaskin/NeuralABM/assets/22022754/476c99e3-a9f5-443f-8c27-f2ea16e13e4d">
 
 
 <img width="656" alt="Screenshot 2024-01-21 at 00 50 07" src="https://github.com/ThGaskin/NeuralABM/assets/22022754/68239667-febd-4611-aff6-9694ced7c1ed">

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
 <img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/4b786ca5-73df-44a0-92d3-2e4732ef25de" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/c2701e7a-c5d2-4afb-907e-2772aae69b3c" width=49%>
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/4ec62487-3956-489c-9a9a-18e36444d40b" width=49%> <img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/d112167b-cc90-48fd-ba8a-8905f3233cd0" width=49%>
 
 
 This project calibrates multi-agent ODE and SDE models to data using a neural network. We estimate marginal densities on the equation parameters, including adjacency matrices. This repository contains all the code and models used in our publications on the topic, as well as an extensive set of tools and examples for you to calibrate your own model:
@@ -207,7 +208,7 @@ This directory structure already hints at the three basic steps that are execute
 
 Open the `eval` folder — in it there will be a further time-stamped folder. Every time you evaluate a simulation, a new folder is created. This way, no evaluation result is ever overwritten. In the `eval/YYMMDD-hhmmss` folder, you should find five plots. Take a look at `densities_from_joint.pdf`, which should look something like this:
 
-<img src="https://github.com/ThGaskin/NeuralABM/files/13787239/densities_from_joint.pdf" width=100%>
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/4a717f2a-945b-45af-932b-b9d8837a3b12" width=100%>
 
 You can see the true data (orange) together with the neural net predictions (blue) and an error estimate (blue shaded area).
 The results aren't great; you will also notice from the `loss.pdf` plot that the training loss has barely decreased. Why? Well, 
@@ -227,7 +228,7 @@ utopya run SIR path/to/run.yml
 ```
 Here, we are *only* updating those entries of the base configuration which are also given in the `run.yml` file; the remaining ones are taken from the default configuration file. The results in the output folder should look something like this:
 
-<img src="https://github.com/ThGaskin/NeuralABM/files/13787372/densities_from_joint.pdf" width=100%>
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/45510697-8d45-4849-a6e6-fd920dd79d58" width=100%>
 
 Perhaps a little bit better, but still not great, and the uncertainty is much too small. The real problem here is that we are only training our neural network from a single initialisation, and letting it find one of the possible parameters that fit the problem. This doesn't give us an accurate representation of the parameter space. What we really need to be doing is training it multiple times, in parallel, from different initialisations, so that it can see the more of the parameter space. This is what we will do in the next section.
 
@@ -263,11 +264,11 @@ The `seed` entry controls the random initialisation of the neural network, and w
 
 Once the run is complete, the plot output should look like this:
 
-<img src="https://github.com/ThGaskin/NeuralABM/files/13787421/densities_from_joint.pdf" width=100%>
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/c357ca9f-3389-4a26-ac17-82f6edc208d2" width=100%>
 
 Much better! You can see that the predicted densities are significantly closer to the true data. The folder also contains the marginal densities on the parameters we are estimating:
 
-<img src="https://github.com/ThGaskin/NeuralABM/files/13787439/marginals.pdf" width=100%>
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/7bf33590-a53f-465d-a9af-5a1f305dfcfb" width=100%>
 
 These too look good: we obtain an infection parameter of about 0.21, and infection period of about 15 days – these are very similar to the values of 0.2 and 14 used to generate the synthetic data.
 
@@ -285,7 +286,8 @@ These too look good: we obtain an infection parameter of about 0.21, and infecti
 
 In your output folder you will also find the following plot:
 
-<img src="https://github.com/ThGaskin/NeuralABM/files/13852798/predictions.pdf" width=100%>
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/8a7e8d1c-3f32-4789-8e62-50c3e5805b62" width=100%>
+
 
 Each line represents a trajectory taken by the neural net during training; as you can see, we are training the net multiple times in parallel, each time initialising the neural network at a different value of the initial distribution – see [the corresponding section](#specifying-the-prior-on-the-output) on how to adjust this distribution. The colour of each line repressents the training loss at that sample.
 The number of initialisations is controlled by the `seed` entry of the run config.
@@ -536,7 +538,7 @@ NeuralNet:
 ```
 This will initialise each parameter with a separate prior. Take a look at the output folder for the `Predictions_on_smooth_data` run; it contains a plot of the initial value distribution:
 
-<img src="https://github.com/ThGaskin/NeuralABM/files/13854397/initial_values.pdf" width=100%>
+<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/4167a956-3473-42ca-8d31-df1ada7d4f5a" width=100%>
 
 ## Training settings
 You can modify the training settings, such as the batch size or the training device, from the

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 
-<img src="https://github.com/ThGaskin/NeuralABM/assets/22022754/e0bf61c7-4fe1-4234-b480-02d1f8efff6b"/> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width="49%"> 
+<img src="https://private-user-images.githubusercontent.com/22022754/294950846-e0bf61c7-4fe1-4234-b480-02d1f8efff6b.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTExMTg1MjIsIm5iZiI6MTcxMTExODIyMiwicGF0aCI6Ii8yMjAyMjc1NC8yOTQ5NTA4NDYtZTBiZjYxYzctNGZlMS00MjM0LWI0ODAtMDJkMWY4ZWZmZjZiLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDAzMjIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwMzIyVDE0MzcwMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTk4YWI4MzE0MzAwYzRlZmZmMWM0NzUzNDFlYjQ3YzAzNjZmMDkwNzkwZDBjZWU3ZDA3ZDgzYmE5NWJjYTc0ZGMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.PBG2XbeZK0pJDpIHJ1dVk4RySojqr8QgqfqCrKjYU10"/> <img src="https://github.com/ThGaskin/NeuralABM/files/13863262/marginals_all.pdf" width="49%"> 
 
 <img src="https://github.com/ThGaskin/NeuralABM/files/13863293/densities_from_joint.pdf"> <img src="https://github.com/ThGaskin/NeuralABM/files/13863249/predictions.pdf" width="49%">
 


### PR DESCRIPTION
Converts the README images to gif and png. This allows them to be displayed correctly on all browsers